### PR TITLE
suggestions.

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -205,15 +205,21 @@ func kubeadmVersion(info string) (string, error) {
 	// Discard offsets after a release label and keep the labels down to e.g. `alpha.0` instead of
 	// including the offset e.g. `alpha.0.206`. This is done to comply with GCR image tags.
 	pre := v.PreRelease()
+	patch := v.Patch()
 	if len(pre) > 0 {
-		split := strings.Split(pre, ".")
-		if len(split) > 2 {
-			pre = split[0] + "." + split[1] // exclude the third element
-		} else if len(split) < 2 {
-			pre = split[0] + ".0" // append .0 to a partial label
+		if patch > 0 {
+			patch = patch - 1
+			pre = ""
+		} else {
+			split := strings.Split(pre, ".")
+			if len(split) > 2 {
+				pre = split[0] + "." + split[1] // exclude the third element
+			} else if len(split) < 2 {
+				pre = split[0] + ".0" // append .0 to a partial label
+			}
+			pre = "-" + pre
 		}
-		pre = "-" + pre
 	}
-	vStr := fmt.Sprintf("v%d.%d.%d%s", v.Major(), v.Minor(), v.Patch(), pre)
+	vStr := fmt.Sprintf("v%d.%d.%d%s", v.Major(), v.Minor(), patch, pre)
 	return vStr, nil
 }

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -313,7 +313,7 @@ func TestKubeadmVersion(t *testing.T) {
 		{
 			name:   "valid patch version with label and extra metadata",
 			input:  "v1.11.3-beta.0.38+135cc4c1f47994",
-			output: "v1.11.3-beta.0",
+			output: "v1.11.2",
 		},
 		{
 			name:   "valid version with label extra",
@@ -323,7 +323,7 @@ func TestKubeadmVersion(t *testing.T) {
 		{
 			name:   "valid patch version with label",
 			input:  "v1.9.11-beta.0",
-			output: "v1.9.11-beta.0",
+			output: "v1.9.10",
 		},
 		{
 			name:   "handle version with partial label",


### PR DESCRIPTION
@neolit123 two suggestions: 
1. prefer stable released versions in fallback situations if patch level is more than 0.
2. simplified handling of non-OK http results in fetchFromURL()